### PR TITLE
修复了#21-执行到openpreview的报错

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,138 @@
+# the name by which the project can be referenced within Serena
+project_name: "OpenCowork"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   java                julia               kotlin              lua                 markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- typescript
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project by name.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_lines`: Deletes a range of lines within a file.
+#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
+#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
+#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Gets the initial instructions for the current project.
+#     Should only be used in settings where the system prompt cannot be set,
+#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_at_line`: Inserts content at a given line in a file.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
+#  * `remove_project`: Removes a project from the Serena configuration.
+#  * `replace_lines`: Replaces a range of lines within a file with new content.
+#  * `replace_symbol_body`: Replaces the full definition of a symbol.
+#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
+#  * `switch_modes`: Activates modes by providing a list of their names
+#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
+#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
+#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
+#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []

--- a/src/main/ipc/fs-handlers.ts
+++ b/src/main/ipc/fs-handlers.ts
@@ -578,7 +578,7 @@ export function registerFsHandlers(): void {
         }
         return content
       } catch (err) {
-        return JSON.stringify({ error: String(err) })
+        return { error: String(err) }
       }
     }
   )

--- a/src/main/ipc/ssh-handlers.ts
+++ b/src/main/ipc/ssh-handlers.ts
@@ -1764,7 +1764,7 @@ export function registerSshHandlers(): void {
         }
         return content
       } catch (err) {
-        return JSON.stringify({ error: String(err) })
+        return { error: String(err) }
       }
     }
   )

--- a/src/renderer/src/hooks/use-file-watcher.ts
+++ b/src/renderer/src/hooks/use-file-watcher.ts
@@ -2,12 +2,31 @@ import { useState, useEffect, useCallback } from 'react'
 import { ipcClient } from '@renderer/lib/ipc/ipc-client'
 import { IPC } from '@renderer/lib/ipc/channels'
 
+function getReadError(result: unknown): string | null {
+  if (result && typeof result === 'object' && 'error' in result) {
+    const error = (result as { error?: unknown }).error
+    return typeof error === 'string' && error.length > 0 ? error : 'Failed to read file'
+  }
+
+  if (typeof result !== 'string' || !result.trim().startsWith('{')) return null
+
+  try {
+    const parsed = JSON.parse(result) as { error?: unknown }
+    return typeof parsed.error === 'string' && parsed.error.length > 0 ? parsed.error : null
+  } catch {
+    return null
+  }
+}
+
 export function useFileWatcher(filePath: string | null, sshConnectionId?: string) {
   const [content, setContent] = useState<string>('')
   const [loading, setLoading] = useState(false)
 
   const loadContent = useCallback(async () => {
-    if (!filePath) return
+    if (!filePath) {
+      setContent('')
+      return
+    }
     setLoading(true)
     try {
       const channel = sshConnectionId ? IPC.SSH_FS_READ_FILE : IPC.FS_READ_FILE
@@ -15,12 +34,14 @@ export function useFileWatcher(filePath: string | null, sshConnectionId?: string
         ? { connectionId: sshConnectionId, path: filePath }
         : { path: filePath }
       const result = await ipcClient.invoke(channel, args)
-      if (result && typeof result === 'object' && 'error' in result) {
-        throw new Error(String((result as { error?: unknown }).error))
+      const readError = getReadError(result)
+      if (readError) {
+        throw new Error(readError)
       }
       setContent(String(result))
     } catch (err) {
       console.error('[useFileWatcher] Failed to read file:', err)
+      setContent('')
     } finally {
       setLoading(false)
     }

--- a/src/renderer/src/lib/agent/memory-files.ts
+++ b/src/renderer/src/lib/agent/memory-files.ts
@@ -160,6 +160,9 @@ export function joinFsPath(basePath: string, ...segments: string[]): string {
 export async function readTextFile(ipc: IPCClient, filePath: string): Promise<ReadTextFileResult> {
   try {
     const result = await ipc.invoke(IPC.FS_READ_FILE, { path: filePath })
+    if (result && typeof result === 'object' && 'error' in result) {
+      return { error: String((result as { error?: unknown }).error ?? 'Failed to read file') }
+    }
     if (typeof result !== 'string') {
       return { error: 'Unexpected fs:read-file response type' }
     }

--- a/src/renderer/src/lib/tools/fs-tool.ts
+++ b/src/renderer/src/lib/tools/fs-tool.ts
@@ -98,13 +98,13 @@ function normalizePath(p: string): string {
   return normalized
 }
 
-function isAbsolutePath(p: string): boolean {
+export function isAbsolutePath(p: string): boolean {
   if (!p) return false
   if (p.startsWith('/') || p.startsWith('\\')) return true
   return /^[a-zA-Z]:[\\/]/.test(p)
 }
 
-function resolveToolPath(inputPath: unknown, workingFolder?: string): string {
+export function resolveToolPath(inputPath: unknown, workingFolder?: string): string {
   const raw = typeof inputPath === 'string' ? inputPath.trim() : ''
   const base = workingFolder?.trim()
   if (!raw || raw === '.') {
@@ -184,6 +184,7 @@ const readHandler: ToolHandler = {
       offset: input.offset,
       limit: input.limit
     })
+    if (isErrorResult(result)) throw new Error(`Read failed: ${result.error}`)
     // IPC returns { type: 'image', mediaType, data } for image files
     if (
       result &&
@@ -300,7 +301,11 @@ const editHandler: ToolHandler = {
     // Read file, perform replacement, write back
     const readCh = isSsh(ctx) ? IPC.SSH_FS_READ_FILE : IPC.FS_READ_FILE
     const readArgs = isSsh(ctx) ? sshArgs(ctx, { path: resolvedPath }) : { path: resolvedPath }
-    const content = String(await ctx.ipc.invoke(readCh, readArgs))
+    const contentResult = await ctx.ipc.invoke(readCh, readArgs)
+    if (isErrorResult(contentResult)) {
+      return encodeToolError(`Read failed: ${contentResult.error}`)
+    }
+    const content = String(contentResult)
     const oldStr = String(input.old_string)
     const newStr = String(input.new_string)
     const replaceAll = Boolean(input.replace_all)

--- a/src/renderer/src/lib/tools/preview-tool.ts
+++ b/src/renderer/src/lib/tools/preview-tool.ts
@@ -1,4 +1,5 @@
 import { toolRegistry } from '../agent/tool-registry'
+import { resolveToolPath } from './fs-tool'
 import { encodeStructuredToolResult } from './tool-result-format'
 import type { ToolHandler } from './tool-types'
 
@@ -38,7 +39,7 @@ const openPreviewHandler: ToolHandler = {
     }
   },
   execute: async (input, ctx) => {
-    const filePath = String(input.file_path)
+    const filePath = resolveToolPath(input.file_path, ctx.workingFolder)
     const viewMode = input.view_mode as 'preview' | 'code' | undefined
     const sshConnectionId = resolveSshConnectionId(filePath, ctx.sshConnectionId)
 


### PR DESCRIPTION
确认到的根因有两层，且本次都已命中：
    - OpenPreview 没有把相对路径按会话 workingFolder 解析，导致预览目标路径错误。
    - fs:read-file 在失败时返回 JSON 字符串而不是 { error } 对象，renderer 侧可能把错误当正文处理。