### PR TITLE
在 README.zh.md 添加 Codex-Manager 友链与搭配使用说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ graph TB
 - **Automated Ops:** Schedule agents to monitor logs or system status and report to Feishu/Slack.
 - **Data Research:** Agents can scrape web data, process local CSVs, and generate visual reports.
 
+## 🔗 Ecosystem Pairing
+
+### Codex-Manager
+
+- Repository: [qxcnm/Codex-Manager](https://github.com/qxcnm/Codex-Manager)
+- Recommended pairing: use Codex-Manager as the management or orchestration entry point for Codex-centric workflows, while OpenCowork handles local file operations, multi-agent execution, workplace messaging, and desktop automation.
+- Best for: teams that want to separate task management and workflow organization from local execution and office integration.
+- A simple way to think about it: **Codex-Manager organizes the work, OpenCowork executes it in the real workspace.**
+
 ## 📈 Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=AIDotNet/OpenCowork&type=Date)](https://star-history.com/#AIDotNet/OpenCowork&Date)

--- a/README.zh.md
+++ b/README.zh.md
@@ -99,6 +99,15 @@ graph TB
 - **自动化运维：** 调度智能体监控日志或系统状态，并汇报至飞书/Slack。
 - **数据调研：** 智能体可以抓取网页数据、处理本地 CSV 并生成可视化报告。
 
+## 🔗 生态搭配
+
+### Codex-Manager
+
+- 仓库地址：[qxcnm/Codex-Manager](https://github.com/qxcnm/Codex-Manager)
+- 搭配方式：使用 Codex-Manager 统一管理 Codex 相关工作流、任务入口或协作编排，再由 OpenCowork 承接本地文件操作、多 Agent 协作、消息平台接入与桌面执行能力。
+- 适合场景：当您希望把“任务管理 / 调度入口”和“本地执行 / 办公协同”拆分开时，这两个项目可以形成互补组合。
+- 推荐理解：**Codex-Manager 更偏管理与组织，OpenCowork 更偏执行与落地。**
+
 ## 📈 Star 历史
 
 [![Star History Chart](https://api.star-history.com/svg?repos=AIDotNet/OpenCowork&type=Date)](https://star-history.com/#AIDotNet/OpenCowork&Date)


### PR DESCRIPTION
## 变更说明
- 在 README.zh.md 添加 Codex-Manager 友链与搭配使用说明
- 在 README.md 添加对应的英文生态搭配说明

## 目的
- 让用户更容易发现 qxcnm/Codex-Manager
- 明确两者的定位互补：Codex-Manager 偏管理与组织，OpenCowork 偏执行与落地

## 验证
- 检查提交范围仅包含 README.md 与 README.zh.md
- 未改动应用逻辑与文档页面