### PR TITLE
fix: UI Optimize

### DIFF
--- a/src/renderer/src/components/chat/ModelSwitcher.tsx
+++ b/src/renderer/src/components/chat/ModelSwitcher.tsx
@@ -296,6 +296,7 @@ function ModelSettingsPopover({
   providerId,
   providerType,
   providerWebsocketMode,
+  side = 'top',
   t,
   tChat,
   tSettings
@@ -304,6 +305,7 @@ function ModelSettingsPopover({
   providerId?: string | null
   providerType?: AIProvider['type']
   providerWebsocketMode?: AIProvider['websocketMode']
+  side?: 'top' | 'bottom'
   t: (key: string) => string
   tChat: (key: string, opts?: Record<string, unknown>) => string
   tSettings: (key: string, opts?: Record<string, unknown>) => string
@@ -494,12 +496,16 @@ function ModelSettingsPopover({
         </button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[388px] overflow-hidden rounded-xl border-border/70 bg-popover/95 p-0 shadow-2xl backdrop-blur"
+        className="w-[388px] max-w-[calc(100vw-1rem)] overflow-hidden rounded-xl border-border/70 bg-popover/95 p-0 shadow-2xl backdrop-blur"
         align="start"
-        side="top"
+        side={side}
         sideOffset={8}
+        collisionPadding={12}
       >
-        <div className="space-y-4 p-4">
+        <div
+          className="space-y-4 overflow-y-auto p-4"
+          style={{ maxHeight: 'min(32rem, var(--radix-popover-content-available-height))' }}
+        >
           {!model && (
             <div className="px-2 py-3 text-center text-xs text-muted-foreground">
               {tChat('input.noModelSettings')}
@@ -850,6 +856,7 @@ export function ModelSwitcher({
   )
   const settingsProviderId = isAutoModeActive ? autoResolvedProvider?.id : displayProvider?.id
   const settingsModel = isAutoModeActive ? (autoResolvedModel ?? undefined) : displayModel
+  const settingsPopoverSide = activeSession ? 'top' : 'bottom'
   const triggerLabel = isAutoModeActive
     ? autoRoutingState === 'routing'
       ? t('topbar.autoModel')
@@ -1481,6 +1488,7 @@ export function ModelSwitcher({
         providerWebsocketMode={
           isAutoModeActive ? autoResolvedProvider?.websocketMode : displayProvider?.websocketMode
         }
+        side={settingsPopoverSide}
         t={t}
         tChat={tChat}
         tSettings={tSettings}

--- a/src/renderer/src/components/layout/SessionConversationPane.tsx
+++ b/src/renderer/src/components/layout/SessionConversationPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import {
   Check,
@@ -193,6 +193,7 @@ export function SessionConversationPane({
   const [folderDialogOpen, setFolderDialogOpen] = useState(false)
   const [renameDialogOpen, setRenameDialogOpen] = useState(false)
   const [renameValue, setRenameValue] = useState('')
+  const conversationPaneRef = useRef<HTMLDivElement | null>(null)
 
   const compactSessionHeader = sessionView.messageCount === 0
   const hasProjectFolderAction = Boolean(sessionView.projectId && sessionView.workingFolder)
@@ -270,7 +271,9 @@ export function SessionConversationPane({
         })
       })
 
-      const node = document.querySelector('[data-message-content]') as HTMLElement | null
+      const node = conversationPaneRef.current?.querySelector(
+        '[data-message-content]'
+      ) as HTMLElement | null
       if (!node) {
         throw new Error('Export target not found')
       }
@@ -298,10 +301,13 @@ export function SessionConversationPane({
           })
         })
 
-        const bgRaw = getComputedStyle(document.documentElement)
-          .getPropertyValue('--background')
-          .trim()
-        const bgColor = bgRaw ? `hsl(${bgRaw})` : '#ffffff'
+        const bodyBackgroundColor = getComputedStyle(document.body).backgroundColor.trim()
+        const bgColor =
+          bodyBackgroundColor && bodyBackgroundColor !== 'rgba(0, 0, 0, 0)'
+            ? bodyBackgroundColor
+            : '#ffffff'
+        exportStage.style.backgroundColor = bgColor
+        exportNode.style.backgroundColor = bgColor
         const { toPng } = await loadHtmlToImage()
         const captureWidth = node.clientWidth
         const captureHeight = Math.max(
@@ -319,6 +325,7 @@ export function SessionConversationPane({
           canvasHeight: captureHeight * 2,
           style: {
             overflow: 'visible',
+            backgroundColor: bgColor,
             maxWidth: `${captureWidth}px`,
             width: `${captureWidth}px`,
             height: `${captureHeight}px`
@@ -598,7 +605,7 @@ export function SessionConversationPane({
         </div>
       </div>
 
-      <div key={conversationRoot} className="flex min-h-0 flex-1 flex-col">
+      <div ref={conversationPaneRef} key={conversationRoot} className="flex min-h-0 flex-1 flex-col">
         <MessageList
           sessionId={resolvedSessionId}
           onRetry={retryLastMessage}


### PR DESCRIPTION
fix: 
1. exportImage is black when theme is light; 
2. modelSetting PopoverTrigger is overlap when new session

<img width="3952" height="8364" alt="image" src="https://github.com/user-attachments/assets/83a41fcf-a03c-40c7-8162-5446016071ed" />

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/ff04c686-31b5-488d-a674-5bfbc94b12ac" />


