### PR TITLE
chore(dev): silence common npm run dev startup warnings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,2 @@
-electron_mirror=https://npmmirror.com/mirrors/electron/
-electron_builder_binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/
 registry=https://registry.npmjs.org/
 ignore-scripts=false

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,7 +38,8 @@ import { registerApiProxyHandlers } from './ipc/api-proxy'
 import {
   registerSettingsHandlers,
   flushSettingsSync,
-  initializeSettingsCache
+  initializeSettingsCache,
+  readSettings
 } from './ipc/settings-handlers'
 
 import { registerSkillsHandlers } from './ipc/skills-handlers'
@@ -159,7 +160,6 @@ function getEnvProxyUrl(): string | null {
 
 async function configureSystemProxy(): Promise<void> {
   try {
-    const { readSettings } = await import('./ipc/settings-handlers')
     const saved = readSettings().systemProxyUrl
     const proxyUrl = typeof saved === 'string' && saved.trim() ? saved.trim() : getEnvProxyUrl()
 

--- a/src/main/lib/native-worker.ts
+++ b/src/main/lib/native-worker.ts
@@ -1071,23 +1071,28 @@ function isNativeWorkerCandidateReady(candidate: string): boolean {
       fs.existsSync(path.join(candidateDir, name)) ||
       fs.existsSync(path.join(candidateDir, 'runtimes', getCurrentRid(), 'native', name))
   )
-  if (sqliteLibrary) return true
-
-  console.warn('[NativeWorker] skipping candidate with missing SQLite native library', {
-    workerPath: candidate,
-    expected: getSqliteNativeLibraryNames()
-  })
-  return false
+  return Boolean(sqliteLibrary)
 }
 
 function findNewestNativeWorkerCandidate(candidates: string[]): string | null {
-  const ready = candidates
+  const existing = candidates.filter((candidate) => fs.existsSync(candidate))
+  const ready = existing
     .filter(isNativeWorkerCandidateReady)
     .map((candidate) => ({
       candidate,
       mtimeMs: fs.statSync(candidate).mtimeMs
     }))
     .sort((a, b) => b.mtimeMs - a.mtimeMs)
+
+  if (ready.length === 0 && existing.length > 0) {
+    console.warn(
+      '[NativeWorker] no usable native worker candidate (missing SQLite native library)',
+      {
+        candidates: existing,
+        expected: getSqliteNativeLibraryNames()
+      }
+    )
+  }
 
   return ready[0]?.candidate ?? null
 }


### PR DESCRIPTION
## Summary
- Remove invalid `.npmrc` Electron mirror keys that npm rejects as unknown project/env config.
- Use a static `readSettings` import in system proxy setup to avoid the Vite mixed static/dynamic import warning.
- Keep native worker candidate selection unchanged, but only warn when no usable candidate remains.

## Test plan
- [x] `npm run typecheck:node`
- [x] eslint on changed files
- [x] `npm run dev` no longer prints:
  - `Unknown project config "electron_mirror"`
  - `Unknown env config "electron-mirror"`
  - vite:reporter mixed import for `settings-handlers`
  - per-candidate `skipping candidate with missing SQLite native library`
- [x] Native worker still starts from Debug path and serves requests

## Notes
Local Electron download mirrors should use env vars if needed:
```bash
export ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
export ELECTRON_BUILDER_BINARIES_MIRROR=https://npmmirror.com/mirrors/electron-builder-binaries/
```