### PR TITLE
fix(chat): 优化折叠动画并修复虚拟列表展开滚动跳动

### DIFF
--- a/src/renderer/src/components/chat/AssistantMessage.tsx
+++ b/src/renderer/src/components/chat/AssistantMessage.tsx
@@ -60,6 +60,7 @@ import { FileChangeCard } from './FileChangeCard'
 import { BashArtifactsCard } from './BashArtifactsCard'
 import { SubAgentCard } from './SubAgentCard'
 import { ThinkingBlock } from './ThinkingBlock'
+import { CollapsibleHeightPanel } from './CollapsibleHeightPanel'
 import { TeamEventCard } from './TeamEventCard'
 import { AskUserQuestionCard } from './AskUserQuestionCard'
 import { OrchestrationBlock } from './OrchestrationBlock'
@@ -2559,7 +2560,8 @@ export function AssistantMessage({
         .map((toolUseId) => {
           const item = toolExecutionOutline.itemByToolUseId.get(toolUseId)
           if (!item || item.visibility === 'hidden') return null
-          if (item.visibility === 'ordinary' && collapsed) return null
+          // Keep ordinary tools mounted for collapsible runs so close tween can measure height.
+          if (item.visibility === 'ordinary' && collapsed && !run.showToggle) return null
 
           const block = normalizedContent[item.blockIndex]
           if (!block || block.type !== 'tool_use') return null
@@ -2582,7 +2584,13 @@ export function AssistantMessage({
               onClick={() => toggleToolRunCollapsed(run)}
             />
           ) : null}
-          {renderedTools}
+          {run.showToggle ? (
+            <CollapsibleHeightPanel open={!collapsed} className="overflow-hidden">
+              <div className="space-y-2">{renderedTools}</div>
+            </CollapsibleHeightPanel>
+          ) : (
+            renderedTools
+          )}
         </React.Fragment>
       )
     }

--- a/src/renderer/src/components/chat/CollapsibleHeightPanel.tsx
+++ b/src/renderer/src/components/chat/CollapsibleHeightPanel.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react'
+import { motion } from 'motion/react'
+
+const PANEL_TRANSITION = { duration: 0.2, ease: 'easeInOut' as const }
+
+interface CollapsibleHeightPanelProps {
+  open: boolean
+  children: React.ReactNode
+  className?: string
+  /** When false, content is always shown without animation (e.g. non-collapsible groups). */
+  enabled?: boolean
+  contentClassName?: string
+}
+
+/**
+ * Height collapse/expand that matches ThinkingBlock:
+ * measure pixel height first, tween number→0 / 0→number, unmount only after close finishes.
+ * Avoids height:'auto' exit jank and AnimatePresence last-frame unmount jolt.
+ */
+export function CollapsibleHeightPanel({
+  open,
+  children,
+  className,
+  enabled = true,
+  contentClassName
+}: CollapsibleHeightPanelProps): React.JSX.Element | null {
+  const [mounted, setMounted] = React.useState(open || !enabled)
+  const [height, setHeight] = React.useState<number | 'auto'>(open || !enabled ? 'auto' : 0)
+  const panelRef = React.useRef<HTMLDivElement>(null)
+  const openRef = React.useRef(open)
+
+  React.useLayoutEffect(() => {
+    if (!enabled) {
+      setMounted(true)
+      setHeight('auto')
+      openRef.current = open
+      return
+    }
+
+    const wasOpen = openRef.current
+    openRef.current = open
+
+    if (open && !wasOpen) {
+      setMounted(true)
+      setHeight(0)
+      requestAnimationFrame(() => {
+        const measured = panelRef.current?.scrollHeight ?? 0
+        setHeight(measured > 0 ? measured : 'auto')
+      })
+      return
+    }
+
+    if (!open && wasOpen) {
+      const measured = panelRef.current?.getBoundingClientRect().height ?? 0
+      setHeight(measured)
+      requestAnimationFrame(() => {
+        setHeight(0)
+      })
+    }
+  }, [enabled, open])
+
+  // Content may resize while open (tool output arrives); keep a px lock when still on auto.
+  React.useLayoutEffect(() => {
+    if (!enabled || !open || !mounted) return
+    if (height !== 'auto') return
+    const measured = panelRef.current?.scrollHeight ?? 0
+    if (measured > 0) setHeight(measured)
+  }, [children, enabled, height, mounted, open])
+
+  if (!enabled) {
+    return <div className={className}>{children}</div>
+  }
+
+  if (!mounted) return null
+
+  const visible = open || height === 'auto' || (typeof height === 'number' && height > 0)
+
+  return (
+    <motion.div
+      ref={panelRef}
+      initial={false}
+      animate={{
+        height,
+        opacity: visible ? 1 : 0
+      }}
+      transition={PANEL_TRANSITION}
+      className={className}
+      onAnimationComplete={() => {
+        if (!open && height === 0) {
+          setMounted(false)
+          return
+        }
+        if (open && typeof height === 'number' && height > 0) {
+          setHeight('auto')
+        }
+      }}
+    >
+      <div className={contentClassName}>{children}</div>
+    </motion.div>
+  )
+}

--- a/src/renderer/src/components/chat/MessageList.tsx
+++ b/src/renderer/src/components/chat/MessageList.tsx
@@ -1697,6 +1697,56 @@ function MessageListInner(props: MessageListProps): React.JSX.Element {
   }, [inlineCompactSummaryState.summaryIds, renderableMessages])
   const hasLoadOlderRow = loadedRangeStart > 0
   const virtualRowCount = rows.length + (hasLoadOlderRow ? 1 : 0)
+
+  const canAutoScroll = React.useCallback(() => {
+    const mode = autoScrollModeRef.current
+    return (
+      mode === 'user' || (mode === 'stream' && canSessionTriggerStreamingAutoScroll && isAtBottom)
+    )
+  }, [canSessionTriggerStreamingAutoScroll, isAtBottom])
+
+  // ---------------------------------------------------------------------------
+  // 【临时修复 / Temporary workaround · 2026-07-10】
+  //
+  // 背景：
+  // MessageList 用 @tanstack/react-virtual 把「整条 assistant 消息」当成一行。
+  // 用户在消息中部展开「工具调用」时，只是行内高度变大，但库默认会走
+  // resizeItem → applyScrollAdjustment：只要该行 start 在视口上方，就
+  // scrollTop += 整段高度差，导致点击位置被顶走。
+  //
+  // 官方原因：
+  // TanStack Virtual 默认补偿策略面向「普通列表行」：视口上方行变高时补 scroll，
+  // 避免历史列表量高后视口内容漂移。聊天场景（一行=整条消息、行内折叠展开）
+  // 默认语义不合适——可见行内部变高时，用户期望视口钉住、内容向下长。
+  //
+  // 社区同类反馈（仍 open）：
+  // https://github.com/TanStack/virtual/issues/1218
+  // 「applyScrollAdjustment causes chat stream viewport to drift downward when
+  //  a visible streaming item keeps growing」
+  // 结论与本场景一致：可见内容自己长高时，不补偿更稳；补偿会把视口拖跑。
+  //
+  // 本钩子是官方预留的策略入口（非业务侧 scrollTop 补丁）：
+  // shouldAdjustScrollPositionOnItemSizeChange
+  //
+  // 策略：
+  // 1) 正在 stick-to-bottom 跟随 → 不让 virtualizer 抢滚动（贴底仍走下方逻辑）
+  // 2) 自由浏览时，仅当「整行完全在视口上方」才补偿
+  // 3) 行与视口相交（中部展开工具调用）→ 不补偿，列表位置保持不动
+  //
+  // 后续维护：
+  // 若官方默认策略/聊天示例修好了 #1218（或提供 chat 专用 anchor 模式），
+  // 评估后可删除本回调，恢复库默认行为。删除前请对照 issue 与手测：
+  // 中部展开/收起工具调用、流式贴底、加载更早消息。
+  // ---------------------------------------------------------------------------
+  const shouldAdjustScrollPositionOnItemSizeChange = React.useCallback(
+    (item: { end: number }, _delta: number, instance: { scrollOffset: number | null }): boolean => {
+      if (canAutoScroll()) return false
+      const scrollOffset = instance.scrollOffset ?? 0
+      return item.end < scrollOffset
+    },
+    [canAutoScroll]
+  )
+
   const rowVirtualizer = useVirtualizer({
     count: virtualRowCount,
     getScrollElement: () => listRef.current,
@@ -1708,6 +1758,11 @@ function MessageListInner(props: MessageListProps): React.JSX.Element {
       return row?.key ?? `row:${index}`
     }
   })
+  // 当前 @tanstack/react-virtual@3.14.5 的 VirtualizerOptions 类型未暴露该钩子，
+  // 但 virtual-core 实例属性存在且 resizeItem 会读它。必须挂到实例上，不能塞进 options
+  //（options 路径 TS 报错且运行时也不会赋到 this.shouldAdjust...）。
+  rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange =
+    shouldAdjustScrollPositionOnItemSizeChange
   const pendingAskUserQuestion = React.useMemo(
     () => findPendingAskUserQuestion(rows, toolResultsLookup, messageLookup),
     [messageLookup, rows, toolResultsLookup]
@@ -1718,13 +1773,6 @@ function MessageListInner(props: MessageListProps): React.JSX.Element {
     (!activeSessionLoaded || activeSessionMessageCount > 0 || loadedRangeStart > 0)
 
   const lastMessageRowIndex = rows.length - 1
-
-  const canAutoScroll = React.useCallback(() => {
-    const mode = autoScrollModeRef.current
-    return (
-      mode === 'user' || (mode === 'stream' && canSessionTriggerStreamingAutoScroll && isAtBottom)
-    )
-  }, [canSessionTriggerStreamingAutoScroll, isAtBottom])
 
   const markProgrammaticScroll = React.useCallback(() => {
     programmaticScrollUntilRef.current = window.performance.now() + PROGRAMMATIC_SCROLL_GUARD_MS

--- a/src/renderer/src/components/chat/ThinkingBlock.tsx
+++ b/src/renderer/src/components/chat/ThinkingBlock.tsx
@@ -20,7 +20,7 @@ import {
   MARKDOWN_REMARK_PLUGINS
 } from '@renderer/lib/preview/viewers/markdown-components'
 import { useStreamingRenderPool } from '@renderer/hooks/use-typewriter'
-import { motion, AnimatePresence } from 'motion/react'
+import { CollapsibleHeightPanel } from './CollapsibleHeightPanel'
 
 interface ThinkingBlockProps {
   thinking: string
@@ -122,129 +122,115 @@ export const ThinkingBlock = memo(function ThinkingBlock({
         )}
       </button>
 
-      <AnimatePresence initial={false}>
-        {expanded && (
-          <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ type: 'spring', stiffness: 400, damping: 30 }}
-            className="mt-2 overflow-hidden"
-          >
-            <div className="max-w-full px-0.5 pb-1 text-sm leading-7 text-muted-foreground/75">
-              {hasThinkingContent ? (
-                <div ref={contentRef} className="max-h-80 overflow-y-auto">
-                  {isThinking ? (
-                    <div
-                      className={`${getLiveOutputSurfaceClass(liveOutputAnimationStyle)} whitespace-pre-wrap break-words leading-relaxed`}
-                      data-render-pool-size={renderPool.poolSize}
-                      data-rendered-length={renderPool.renderedLength}
-                      data-target-length={renderPool.targetLength}
-                    >
-                      {renderPool.text}
-                      <span className={getLiveOutputCursorClass(liveOutputAnimationStyle)} />
-                    </div>
-                  ) : (
-                    <div className="[&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5 [&_li]:my-1">
-                      <Markdown
-                        remarkPlugins={MARKDOWN_REMARK_PLUGINS}
-                        rehypePlugins={MARKDOWN_REHYPE_PLUGINS}
-                        components={{
-                          a: ({ href, children, ...props }) => (
-                            <a
-                              {...props}
-                              href={href}
-                              className="text-primary underline underline-offset-2 hover:text-primary/80 break-all"
-                              onClick={(event) => {
-                                if (!href) return
-                                const handled = openMarkdownHref(href)
-                                if (handled) event.preventDefault()
-                              }}
-                            >
-                              {children}
-                            </a>
-                          ),
-                          code: ({ children, className, ...props }) => {
-                            const isInline = !className
-                            if (isInline) {
-                              const code = String(children ?? '').replace(/\n$/, '')
-                              const resolvedPath = resolveLocalFilePath(code)
-                              if (resolvedPath) {
-                                return (
-                                  <button
-                                    type="button"
-                                    className="cursor-pointer rounded bg-muted px-1 py-0.5 text-xs font-mono text-primary underline-offset-2 hover:underline"
-                                    style={{ fontFamily: MONO_FONT }}
-                                    title={resolvedPath}
-                                    onClick={() => {
-                                      void openLocalFilePath(code)
-                                    }}
-                                  >
-                                    {children}
-                                  </button>
-                                )
-                              }
-                              return (
-                                <code
-                                  className="rounded bg-muted px-1 py-0.5 text-xs font-mono"
-                                  style={{ fontFamily: MONO_FONT }}
-                                  {...props}
-                                >
-                                  {children}
-                                </code>
-                              )
-                            }
-                            return (
-                              <code
-                                className={className}
-                                style={{ fontFamily: MONO_FONT }}
-                                {...props}
-                              >
-                                {children}
-                              </code>
-                            )
-                          }
-                        }}
-                      >
-                        {thinking}
-                      </Markdown>
-                    </div>
-                  )}
+      <CollapsibleHeightPanel open={expanded} className="overflow-hidden">
+        <div className="max-w-full px-0.5 pb-1 text-sm leading-7 text-muted-foreground/75">
+          {hasThinkingContent ? (
+            <div ref={contentRef} className="max-h-80 overflow-y-auto">
+              {isThinking ? (
+                <div
+                  className={`${getLiveOutputSurfaceClass(liveOutputAnimationStyle)} whitespace-pre-wrap break-words leading-relaxed`}
+                  data-render-pool-size={renderPool.poolSize}
+                  data-rendered-length={renderPool.renderedLength}
+                  data-target-length={renderPool.targetLength}
+                >
+                  {renderPool.text}
+                  <span className={getLiveOutputCursorClass(liveOutputAnimationStyle)} />
                 </div>
               ) : (
-                <div
-                  role="status"
-                  aria-live="polite"
-                  className={`thinking-live-status ${getLiveOutputThinkingClass(liveOutputAnimationStyle)}`}
-                >
-                  <span className="thinking-live-dots" aria-hidden="true">
-                    <span
-                      className={getLiveOutputDotClass(liveOutputAnimationStyle)}
-                      style={{ animationDelay: '0ms' }}
-                    />
-                    <span
-                      className={getLiveOutputDotClass(liveOutputAnimationStyle)}
-                      style={{ animationDelay: '150ms' }}
-                    />
-                    <span
-                      className={getLiveOutputDotClass(liveOutputAnimationStyle)}
-                      style={{ animationDelay: '300ms' }}
-                    />
-                  </span>
-                  <span className="thinking-live-label">
-                    {t('thinking.pending', { defaultValue: 'Thinking' })}
-                  </span>
-                  {liveElapsed > 0 && (
-                    <span className="thinking-live-meta" aria-label={durationLabel}>
-                      {compactElapsedLabel}
-                    </span>
-                  )}
+                <div className="[&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:my-2 [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5 [&_li]:my-1">
+                  <Markdown
+                    remarkPlugins={MARKDOWN_REMARK_PLUGINS}
+                    rehypePlugins={MARKDOWN_REHYPE_PLUGINS}
+                    components={{
+                      a: ({ href, children, ...props }) => (
+                        <a
+                          {...props}
+                          href={href}
+                          className="text-primary underline underline-offset-2 hover:text-primary/80 break-all"
+                          onClick={(event) => {
+                            if (!href) return
+                            const handled = openMarkdownHref(href)
+                            if (handled) event.preventDefault()
+                          }}
+                        >
+                          {children}
+                        </a>
+                      ),
+                      code: ({ children, className, ...props }) => {
+                        const isInline = !className
+                        if (isInline) {
+                          const code = String(children ?? '').replace(/\n$/, '')
+                          const resolvedPath = resolveLocalFilePath(code)
+                          if (resolvedPath) {
+                            return (
+                              <button
+                                type="button"
+                                className="cursor-pointer rounded bg-muted px-1 py-0.5 text-xs font-mono text-primary underline-offset-2 hover:underline"
+                                style={{ fontFamily: MONO_FONT }}
+                                title={resolvedPath}
+                                onClick={() => {
+                                  void openLocalFilePath(code)
+                                }}
+                              >
+                                {children}
+                              </button>
+                            )
+                          }
+                          return (
+                            <code
+                              className="rounded bg-muted px-1 py-0.5 text-xs font-mono"
+                              style={{ fontFamily: MONO_FONT }}
+                              {...props}
+                            >
+                              {children}
+                            </code>
+                          )
+                        }
+                        return (
+                          <code className={className} style={{ fontFamily: MONO_FONT }} {...props}>
+                            {children}
+                          </code>
+                        )
+                      }
+                    }}
+                  >
+                    {thinking}
+                  </Markdown>
                 </div>
               )}
             </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+          ) : (
+            <div
+              role="status"
+              aria-live="polite"
+              className={`thinking-live-status ${getLiveOutputThinkingClass(liveOutputAnimationStyle)}`}
+            >
+              <span className="thinking-live-dots" aria-hidden="true">
+                <span
+                  className={getLiveOutputDotClass(liveOutputAnimationStyle)}
+                  style={{ animationDelay: '0ms' }}
+                />
+                <span
+                  className={getLiveOutputDotClass(liveOutputAnimationStyle)}
+                  style={{ animationDelay: '150ms' }}
+                />
+                <span
+                  className={getLiveOutputDotClass(liveOutputAnimationStyle)}
+                  style={{ animationDelay: '300ms' }}
+                />
+              </span>
+              <span className="thinking-live-label">
+                {t('thinking.pending', { defaultValue: 'Thinking' })}
+              </span>
+              {liveElapsed > 0 && (
+                <span className="thinking-live-meta" aria-label={durationLabel}>
+                  {compactElapsedLabel}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      </CollapsibleHeightPanel>
     </div>
   )
 })

--- a/src/renderer/src/components/chat/ToolCallCard.tsx
+++ b/src/renderer/src/components/chat/ToolCallCard.tsx
@@ -49,6 +49,7 @@ import { useUIStore } from '@renderer/stores/ui-store'
 import { Button } from '@renderer/components/ui/button'
 import { LazySyntaxHighlighter } from './LazySyntaxHighlighter'
 import { inputSummary } from './tool-call-summary'
+import { CollapsibleHeightPanel } from './CollapsibleHeightPanel'
 import { useChatActions } from '@renderer/hooks/use-chat-actions'
 import { ImagePreview } from './ImagePreview'
 import { ExtensionToolResultCard } from './ExtensionToolResultCard'
@@ -3456,212 +3457,204 @@ function ToolCallCardInner({
         )}
       </button>
 
-      {/* Expanded details */}
-      {open && (
-        <div
-          className={cn(
-            'min-w-0 overflow-hidden',
-            useCompactToolHeader
-              ? 'ml-3 mt-1.5 border-l border-border/45 pl-5 dark:border-white/[0.08]'
-              : 'mt-1.5 pl-5'
-          )}
-        >
-          <div
-            className={cn(
-              'space-y-2 pb-0.5',
-              useCompactToolHeader &&
-                'rounded-lg border border-border/55 bg-background/55 px-3 py-3 dark:border-white/[0.08] dark:bg-[#0d0d0e]'
-            )}
-          >
-            {hideLivePayload ? (
-              <div className="space-y-2">
-                <StructuredInput name={name} input={input} status={status} />
-                <div className="rounded-md border border-border/70 bg-muted/20 px-3 py-2 text-[11px] text-muted-foreground/70">
-                  {t('toolCall.hiddenLivePayload')}
-                </div>
-              </div>
-            ) : (
-              <>
-                {/* Write: show content with syntax highlighting */}
-                {showSettledWriteContent &&
-                  name === 'Write' &&
-                  (() => {
-                    const writeContent = typeof input.content === 'string' ? input.content : null
-                    const writePreview =
-                      typeof input.content_preview === 'string' ? input.content_preview : null
-                    const writePreviewTail =
-                      typeof input.content_preview_tail === 'string'
-                        ? input.content_preview_tail
-                        : null
-                    const displayContent =
-                      writeContent ??
-                      (writePreviewTail
-                        ? `${writePreview}\n…\n${writePreviewTail}`
-                        : writePreview) ??
-                      ''
-                    const isOmitted = !writeContent && !!input.content_omitted
-                    const totalLines =
-                      typeof input.content_lines === 'number'
-                        ? input.content_lines
-                        : writeContent
-                          ? writeContent.split('\n').length
-                          : null
-                    return (
-                      <div>
-                        <div className="mb-1 flex items-center gap-1.5">
-                          <p className="text-xs font-medium text-muted-foreground">
-                            {t('toolCall.content')}
-                          </p>
-                          <span className="text-[9px] text-muted-foreground/55 font-mono">
-                            {detectLang(String(input.file_path ?? input.path ?? ''))}
-                            {totalLines !== null
-                              ? ` · ${t('toolCall.lineCount', { count: totalLines })}`
-                              : ''}
-                          </span>
-                          {isOmitted && (
-                            <span className="rounded bg-muted px-1 py-0.5 text-[9px] text-muted-foreground/60">
-                              {t('toolCall.preview')}
-                            </span>
-                          )}
-                          {writeContent && <CopyBtn text={writeContent} />}
-                        </div>
-                        <LazySyntaxHighlighter
-                          language={detectLang(String(input.file_path ?? input.path ?? ''))}
-                          wrapLongLines
-                          customStyle={{
-                            margin: 0,
-                            padding: '0.5rem',
-                            borderRadius: '0.375rem',
-                            fontSize: '11px',
-                            maxHeight: '200px',
-                            overflow: 'auto',
-                            fontFamily: MONO_FONT
-                          }}
-                          codeTagProps={{ style: { fontFamily: 'inherit' } }}
-                        >
-                          {displayContent}
-                        </LazySyntaxHighlighter>
-                      </div>
-                    )
-                  })()}
-                {/* Structured Input — tool-specific rendering */}
-                {shouldShowStructuredInput && (
-                  <div className="space-y-2">
-                    <ToolDetailSectionHeader label={t('toolCall.parameters')} />
-                    <StructuredInput name={name} input={input} status={status} />
-                  </div>
-                )}
-                {shouldShowResultHeader && <ToolDetailSectionHeader label={t('toolCall.result')} />}
-                {/* Output — tool-specific rendering */}
-                {output && name === 'Read' && hasImageBlocks(output) && (
-                  <ImageOutputBlock output={output} />
-                )}
-                {shouldRenderOutputPanels &&
-                  output &&
-                  name === 'Read' &&
-                  !hasImageBlocks(output) &&
-                  readTextOutputRevealed &&
-                  outputText && (
-                    <ReadOutputBlock
-                      output={outputText}
-                      filePath={String(input.file_path ?? input.path ?? '')}
-                    />
-                  )}
-                {shouldRenderOutputPanels &&
-                  isCommandTool &&
-                  (status === 'running' ||
-                    status === 'streaming' ||
-                    outputText ||
-                    getBashInputTerminalId(input) ||
-                    getShellInputCommand(input)) && (
-                    <BashOutputBlock
-                      name={name}
-                      output={outputText ?? ''}
-                      input={input}
-                      toolUseId={toolUseId}
-                      status={status}
-                    />
-                  )}
-                {shouldRenderOutputPanels && output && name === 'Grep' && outputText && (
-                  <GrepOutputBlock output={outputText} pattern={String(input.pattern ?? '')} />
-                )}
-                {shouldRenderOutputPanels && output && name === 'Glob' && outputText && (
-                  <GlobOutputBlock output={outputText} />
-                )}
-                {shouldRenderOutputPanels && output && name === 'LS' && outputText && (
-                  <LSOutputBlock output={outputText} />
-                )}
-                {shouldRenderOutputPanels &&
-                  output &&
-                  ['Edit', 'Write', 'Delete'].includes(name) &&
-                  (() => {
-                    const s = outputText ?? ''
-                    const parsed = decodeStructuredToolResult(s)
-                    const success = !!(parsed && !Array.isArray(parsed) && parsed.success === true)
-                    return (
-                      <div className="flex items-center gap-1.5 text-xs">
-                        {success ? (
-                          <>
-                            <CheckCircle2 className="size-3 text-green-500" />
-                            <span className="text-green-500/70">
-                              {t('toolCall.appliedSuccessfully')}
-                            </span>
-                          </>
-                        ) : (
-                          <>
-                            <XCircle className="size-3 text-destructive" />
-                            <span className="text-destructive/70 font-mono truncate">
-                              {s.slice(0, 100)}
-                            </span>
-                          </>
-                        )}
-                      </div>
-                    )
-                  })()}
-                {shouldRenderOutputPanels && output && extensionToolResult && (
-                  <ExtensionToolResultCard output={output} />
-                )}
-                {shouldRenderOutputPanels &&
-                  output &&
-                  !extensionToolResult &&
-                  ![
-                    'Read',
-                    'Bash',
-                    'Shell',
-                    'PowerShell',
-                    'Grep',
-                    'Glob',
-                    'LS',
-                    'TaskCreate',
-                    'TaskUpdate',
-                    'TaskGet',
-                    'TaskList',
-                    'Edit',
-                    'Write',
-                    'Delete',
-                    'AskUserQuestion',
-                    'Skill',
-                    'visualize_show_widget'
-                  ].includes(name) &&
-                  (hasImageBlocks(output) ? (
-                    <ImageOutputBlock output={output} />
-                  ) : outputText ? (
-                    <OutputBlock output={outputText} />
-                  ) : null)}
-                {/* Error */}
-                {displayError && (
-                  <div>
-                    <p className="mb-1 text-xs font-medium text-destructive">{t('error.label')}</p>
-                    <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words text-xs text-destructive font-mono">
-                      {displayError}
-                    </pre>
-                  </div>
-                )}
-              </>
-            )}
+      {/* Expanded details — same pixel-height tween as ThinkingBlock */}
+      <CollapsibleHeightPanel
+        open={open}
+        className={cn(
+          'min-w-0 overflow-hidden',
+          useCompactToolHeader
+            ? 'ml-3 mt-1.5 border-l border-border/45 pl-5 dark:border-white/[0.08]'
+            : 'mt-1.5 pl-5'
+        )}
+        contentClassName={cn(
+          'space-y-2 pb-0.5',
+          useCompactToolHeader &&
+            'rounded-lg border border-border/55 bg-background/55 px-3 py-3 dark:border-white/[0.08] dark:bg-[#0d0d0e]'
+        )}
+      >
+        {hideLivePayload ? (
+          <div className="space-y-2">
+            <StructuredInput name={name} input={input} status={status} />
+            <div className="rounded-md border border-border/70 bg-muted/20 px-3 py-2 text-[11px] text-muted-foreground/70">
+              {t('toolCall.hiddenLivePayload')}
+            </div>
           </div>
-        </div>
-      )}
+        ) : (
+          <>
+            {/* Write: show content with syntax highlighting */}
+            {showSettledWriteContent &&
+              name === 'Write' &&
+              (() => {
+                const writeContent = typeof input.content === 'string' ? input.content : null
+                const writePreview =
+                  typeof input.content_preview === 'string' ? input.content_preview : null
+                const writePreviewTail =
+                  typeof input.content_preview_tail === 'string' ? input.content_preview_tail : null
+                const displayContent =
+                  writeContent ??
+                  (writePreviewTail ? `${writePreview}\n…\n${writePreviewTail}` : writePreview) ??
+                  ''
+                const isOmitted = !writeContent && !!input.content_omitted
+                const totalLines =
+                  typeof input.content_lines === 'number'
+                    ? input.content_lines
+                    : writeContent
+                      ? writeContent.split('\n').length
+                      : null
+                return (
+                  <div>
+                    <div className="mb-1 flex items-center gap-1.5">
+                      <p className="text-xs font-medium text-muted-foreground">
+                        {t('toolCall.content')}
+                      </p>
+                      <span className="text-[9px] text-muted-foreground/55 font-mono">
+                        {detectLang(String(input.file_path ?? input.path ?? ''))}
+                        {totalLines !== null
+                          ? ` · ${t('toolCall.lineCount', { count: totalLines })}`
+                          : ''}
+                      </span>
+                      {isOmitted && (
+                        <span className="rounded bg-muted px-1 py-0.5 text-[9px] text-muted-foreground/60">
+                          {t('toolCall.preview')}
+                        </span>
+                      )}
+                      {writeContent && <CopyBtn text={writeContent} />}
+                    </div>
+                    <LazySyntaxHighlighter
+                      language={detectLang(String(input.file_path ?? input.path ?? ''))}
+                      wrapLongLines
+                      customStyle={{
+                        margin: 0,
+                        padding: '0.5rem',
+                        borderRadius: '0.375rem',
+                        fontSize: '11px',
+                        maxHeight: '200px',
+                        overflow: 'auto',
+                        fontFamily: MONO_FONT
+                      }}
+                      codeTagProps={{ style: { fontFamily: 'inherit' } }}
+                    >
+                      {displayContent}
+                    </LazySyntaxHighlighter>
+                  </div>
+                )
+              })()}
+            {/* Structured Input — tool-specific rendering */}
+            {shouldShowStructuredInput && (
+              <div className="space-y-2">
+                <ToolDetailSectionHeader label={t('toolCall.parameters')} />
+                <StructuredInput name={name} input={input} status={status} />
+              </div>
+            )}
+            {shouldShowResultHeader && <ToolDetailSectionHeader label={t('toolCall.result')} />}
+            {/* Output — tool-specific rendering */}
+            {output && name === 'Read' && hasImageBlocks(output) && (
+              <ImageOutputBlock output={output} />
+            )}
+            {shouldRenderOutputPanels &&
+              output &&
+              name === 'Read' &&
+              !hasImageBlocks(output) &&
+              readTextOutputRevealed &&
+              outputText && (
+                <ReadOutputBlock
+                  output={outputText}
+                  filePath={String(input.file_path ?? input.path ?? '')}
+                />
+              )}
+            {shouldRenderOutputPanels &&
+              isCommandTool &&
+              (status === 'running' ||
+                status === 'streaming' ||
+                outputText ||
+                getBashInputTerminalId(input) ||
+                getShellInputCommand(input)) && (
+                <BashOutputBlock
+                  name={name}
+                  output={outputText ?? ''}
+                  input={input}
+                  toolUseId={toolUseId}
+                  status={status}
+                />
+              )}
+            {shouldRenderOutputPanels && output && name === 'Grep' && outputText && (
+              <GrepOutputBlock output={outputText} pattern={String(input.pattern ?? '')} />
+            )}
+            {shouldRenderOutputPanels && output && name === 'Glob' && outputText && (
+              <GlobOutputBlock output={outputText} />
+            )}
+            {shouldRenderOutputPanels && output && name === 'LS' && outputText && (
+              <LSOutputBlock output={outputText} />
+            )}
+            {shouldRenderOutputPanels &&
+              output &&
+              ['Edit', 'Write', 'Delete'].includes(name) &&
+              (() => {
+                const s = outputText ?? ''
+                const parsed = decodeStructuredToolResult(s)
+                const success = !!(parsed && !Array.isArray(parsed) && parsed.success === true)
+                return (
+                  <div className="flex items-center gap-1.5 text-xs">
+                    {success ? (
+                      <>
+                        <CheckCircle2 className="size-3 text-green-500" />
+                        <span className="text-green-500/70">
+                          {t('toolCall.appliedSuccessfully')}
+                        </span>
+                      </>
+                    ) : (
+                      <>
+                        <XCircle className="size-3 text-destructive" />
+                        <span className="text-destructive/70 font-mono truncate">
+                          {s.slice(0, 100)}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                )
+              })()}
+            {shouldRenderOutputPanels && output && extensionToolResult && (
+              <ExtensionToolResultCard output={output} />
+            )}
+            {shouldRenderOutputPanels &&
+              output &&
+              !extensionToolResult &&
+              ![
+                'Read',
+                'Bash',
+                'Shell',
+                'PowerShell',
+                'Grep',
+                'Glob',
+                'LS',
+                'TaskCreate',
+                'TaskUpdate',
+                'TaskGet',
+                'TaskList',
+                'Edit',
+                'Write',
+                'Delete',
+                'AskUserQuestion',
+                'Skill',
+                'visualize_show_widget'
+              ].includes(name) &&
+              (hasImageBlocks(output) ? (
+                <ImageOutputBlock output={output} />
+              ) : outputText ? (
+                <OutputBlock output={outputText} />
+              ) : null)}
+            {/* Error */}
+            {displayError && (
+              <div>
+                <p className="mb-1 text-xs font-medium text-destructive">{t('error.label')}</p>
+                <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words text-xs text-destructive font-mono">
+                  {displayError}
+                </pre>
+              </div>
+            )}
+          </>
+        )}
+      </CollapsibleHeightPanel>
     </div>
   )
 }

--- a/src/renderer/src/components/chat/ToolCallGroup.tsx
+++ b/src/renderer/src/components/chat/ToolCallGroup.tsx
@@ -2,10 +2,10 @@ import * as React from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ChevronRight, ChevronDown, Loader2, Check, X } from 'lucide-react'
-import { AnimatePresence, motion } from 'motion/react'
 import type { ToolCallStatus } from '@renderer/lib/agent/types'
 import type { ToolResultContent } from '@renderer/lib/api/types'
 import { inputSummary, summarizeSearchToolOutput } from './tool-call-summary'
+import { CollapsibleHeightPanel } from './CollapsibleHeightPanel'
 
 const COMMAND_TOOL_NAMES = new Set(['Bash', 'Shell', 'PowerShell'])
 
@@ -156,23 +156,17 @@ export function ToolCallGroup({
         </button>
       ) : null}
 
-      <AnimatePresence initial={false}>
-        {contentVisible && (
-          <motion.div
-            initial={collapsible ? { height: 0, opacity: 0 } : false}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={collapsible ? { height: 0, opacity: 0 } : undefined}
-            transition={{ duration: collapsible ? 0.2 : 0 }}
-            className={
-              collapsible
-                ? 'ml-3 mt-1.5 overflow-hidden border-l border-border/50 pl-5 dark:border-white/[0.08]'
-                : 'overflow-visible'
-            }
-          >
-            {children}
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <CollapsibleHeightPanel
+        open={contentVisible}
+        enabled={collapsible}
+        className={
+          collapsible
+            ? 'ml-3 mt-1.5 overflow-hidden border-l border-border/50 pl-5 dark:border-white/[0.08]'
+            : 'overflow-visible'
+        }
+      >
+        {children}
+      </CollapsibleHeightPanel>
     </div>
   )
 }


### PR DESCRIPTION
## 摘要
- 新增 `CollapsibleHeightPanel`：先测量像素高度，再用 tween 做展开/收起，动画结束后再卸载，避免 `height: auto` 收起尾帧顿一下。
- 「已深度思考」、工具分组、单条工具详情、消息内「工具调用」整组，统一走同一套折叠动画。
- 修复聊天虚拟列表中部展开时，TanStack Virtual 默认 `applyScrollAdjustment` 把列表顶走的问题（见 [TanStack/virtual#1218](https://github.com/TanStack/virtual/issues/1218)）。

## 测试计划
- [ ] 点击「已深度思考」展开/收起，确认动画顺滑，收起末尾无明显顿挫
- [ ] 点击「工具调用」折叠行展开/收起，确认与深度思考同款动画
- [ ] 展开单条工具详情，确认动画一致
- [ ] 在消息列表中部展开工具调用，确认列表不会自动重定位/被顶走
- [ ] 流式输出贴底、滚动到底部按钮、向上加载历史消息仍正常

## 说明
MessageList 中对 `shouldAdjustScrollPositionOnItemSizeChange` 的处理带中文注释，标明这是针对官方默认补偿策略与聊天行内折叠语义冲突的临时修复；若上游修好 #1218 或提供聊天专用 anchor 模式，可评估移除。