### PR TITLE
修复 Windows 绿色版压缩包构建失败

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,8 +208,7 @@ jobs:
         if: matrix.platform == 'win'
         run: >-
           npx electron-builder --win zip --${{ matrix.build_arch }}
-          -c.extraMetadata.opencoworkDistribution=green
-          -c.directories.output=dist-green
+          --config electron-builder.green.yml
           --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/electron-builder.green.yml
+++ b/electron-builder.green.yml
@@ -1,0 +1,5 @@
+extends: ./electron-builder.yml
+directories:
+  output: dist-green
+extraMetadata:
+  opencoworkDistribution: green

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -10,6 +10,7 @@ files:
   - '!dist-green{,/**/*}'
   - '!**/.vscode/*'
   - '!src/*'
+  - '!electron-builder.green.yml'
   - '!electron.vite.config.{js,ts,mjs,cjs}'
   - '!{.eslintcache,eslint.config.mjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}'
   - '!{.env,.env.*,.npmrc,pnpm-lock.yaml}'

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "postinstall": "node ./scripts/postinstall.mjs",
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run build && electron-builder --win",
-    "build:win:green": "npm run build && electron-builder --win zip -c.extraMetadata.opencoworkDistribution=green -c.directories.output=dist-green --publish never",
+    "build:win:green": "npm run build && electron-builder --win zip --config electron-builder.green.yml --publish never",
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux"
   },


### PR DESCRIPTION
## 问题说明

此前的绿色版功能已经通过 #125 合并，当前主线中相关代码仍然存在，并未被回撤。

在 1.1.1 发布构建中，Windows 绿色版压缩包打包失败。electron-builder 将命令行中的点号配置参数错误识别为配置文件路径，最终尝试读取不存在的 `.directories.output=dist-green` 文件。

失败记录：
https://github.com/AIDotNet/OpenCowork/actions/runs/29311652738

## 修改内容

- 新增独立的绿色版构建配置文件，继承现有主配置
- 将绿色版输出目录固定为 `dist-green`
- 保留 `opencoworkDistribution=green` 标记
- GitHub Actions 和本地构建命令统一使用同一份绿色版配置
- 防止绿色版构建配置文件被打入应用压缩包

## 已完成验证

- 已基于最新的 `origin/main` 修改，基点为 `2d9994e9`
- 使用项目当前安装的 electron-builder 26.3.3 验证配置加载和继承
- 确认安装版仍输出到 `dist`，且不携带绿色版标记
- 确认绿色版输出到 `dist-green`，并携带绿色版标记
- 格式检查通过
- 差异检查通过

## 合并前必须完成的验证

当前修改尚未在 Windows 环境中进行实际打包测试，不能仅凭本地配置解析结果直接合并。

合并前必须在 GitHub Actions 的 Windows 构建环境中完成以下验证：

- Windows x64 绿色版压缩包构建成功
- Windows ARM64 绿色版压缩包构建成功
- 不再出现 `.directories.output=dist-green` 文件不存在错误
- 绿色版产物包含正确的 `opencoworkDistribution=green` 标记
- 安装版产物不包含绿色版标记
- 最终能够生成对应架构的绿色版压缩包

在上述 Windows 构建验证全部通过之前，请不要合并本次修改。
