### PR TITLE
feat: 对于Anthropic风格和OpenAI Responses风格模型的连通性校验通过chat接口实现

### DIFF
--- a/src/renderer/src/components/settings/ProviderPanel.tsx
+++ b/src/renderer/src/components/settings/ProviderPanel.tsx
@@ -2293,8 +2293,7 @@ function ProviderConfigPanel({ provider }: { provider: AIProvider }): React.JSX.
       let method = 'POST'
       let body: string | undefined
       if (isAnthropic) {
-        url = `${baseUrl}/v1/models`
-        method = 'GET'
+        url = `${baseUrl}/v1/messages`
         if (useAnthropicCompatAuth) {
           headers['Authorization'] = `Bearer ${activeProvider.apiKey}`
           headers['x-api-key'] = activeProvider.apiKey
@@ -2303,17 +2302,27 @@ function ProviderConfigPanel({ provider }: { provider: AIProvider }): React.JSX.
         }
         headers['anthropic-version'] = '2023-06-01'
         applyHeaderOverrides(model)
+        body = JSON.stringify({
+          model,
+          max_tokens: 1,
+          messages: [{ role: 'user', content: 'Hi' }],
+          ...(activeProvider.requestOverrides?.body ?? {})
+        })
       } else if (isResponses) {
-        url = `${baseUrl}/models`
+        url = `${baseUrl}/responses`
         if (activeProvider.builtinId === 'codex-oauth') {
           url = withCodexClientVersion(url, headers['User-Agent'])
         }
-        method = 'GET'
         if (authToken) headers['Authorization'] = `Bearer ${authToken}`
         if (activeProvider.oauth?.accountId) {
           headers['Chatgpt-Account-Id'] = activeProvider.oauth.accountId
         }
         applyHeaderOverrides(model)
+        body = JSON.stringify({
+          model,
+          input: "Hi",
+          ...(activeProvider.requestOverrides?.body ?? {})
+        })
       } else {
         url = `${baseUrl}/chat/completions`
         if (authToken) headers['Authorization'] = `Bearer ${authToken}`


### PR DESCRIPTION
使用model校验会导致当配置某些模型提供商（xiaomi, deepseek 等）时，model路径与baseUrl发生错误拼接
就像这样 https://token-plan-cn.xiaomimimo.com/anthropic/v1/model ，导致校验失败，但是对话正常。如果使用chat接口，则不会出现这样的问题，且更符合校验模型连通性功能的语义